### PR TITLE
feat: implemented new fonts in extension

### DIFF
--- a/apps/extension/src/extension.ts
+++ b/apps/extension/src/extension.ts
@@ -13,6 +13,7 @@ import {
     type LiveFileItem,
 } from './ui/aegisSidebarPanel';
 import { scan, type ScanResponse, type Severity, type Vulnerability } from './api/scanApi';
+import { getIdeClientName } from './utils/ideClient';
 import { logger } from './utils/logger';
 
 export async function activate(context: vscode.ExtensionContext) {
@@ -121,7 +122,7 @@ export async function activate(context: vscode.ExtensionContext) {
                 totalIssues: totalIssues(),
                 liveFiles: liveFiles(),
                 username: username || undefined,
-                ide: 'VS Code',
+                ide: getIdeClientName(),
             });
             return;
         }
@@ -137,7 +138,7 @@ export async function activate(context: vscode.ExtensionContext) {
             totalIssues: totalIssues(),
             recentScans,
             username: username || undefined,
-            ide: 'VS Code',
+            ide: getIdeClientName(),
         });
     };
 

--- a/apps/extension/src/ui/activeFindingsPanel.ts
+++ b/apps/extension/src/ui/activeFindingsPanel.ts
@@ -1,6 +1,11 @@
 import * as vscode from "vscode";
 import type { Vulnerability, ScanResponse, Severity } from "../api/scanApi";
 import {
+  buildWebviewStyles,
+  severityColor as themeSeverityColor,
+  WEBVIEW_FONT_CSP,
+} from "./webviewTheme";
+import {
   AlertTriangle,
   AlertCircle,
   Info,
@@ -144,28 +149,22 @@ class ActiveFindingsPanel {
   }
 
   private severityColor(severity: Severity): string {
-    const map: Record<Severity, string> = {
-      critical: "#E05A5A",
-      high: "#ff9d12",
-      medium: "#dfc15b",
-      low: "#7A9970",
-      info: "#7fa0b7",
-    };
-    return map[severity];
+    return themeSeverityColor(severity);
   }
 
   private severityIcon(severity: Severity, size = 14): string {
+    const color = this.severityColor(severity);
     switch (severity) {
       case "critical":
-        return `<span style="color:#E05A5A">${AlertTriangle(size)}</span>`;
+        return `<span style="color:${color}">${AlertTriangle(size)}</span>`;
       case "high":
-        return `<span style="color:#ff9d12">${AlertCircle(size)}</span>`;
+        return `<span style="color:${color}">${AlertCircle(size)}</span>`;
       case "medium":
-        return `<span style="color:#dfc15b">${Info(size)}</span>`;
+        return `<span style="color:${color}">${Info(size)}</span>`;
       case "low":
-        return `<span style="color:#7A9970">${CheckCircle(size)}</span>`;
+        return `<span style="color:${color}">${CheckCircle(size)}</span>`;
       default:
-        return `<span style="color:#7fa0b7">${Info(size)}</span>`;
+        return `<span style="color:${color}">${Info(size)}</span>`;
     }
   }
 
@@ -235,10 +234,10 @@ class ActiveFindingsPanel {
                     <span class="dot">|</span> Line ${selected.line}
                 </div>
 
-                <div class="section-label">DIAGNOSIS</div>
+                <div class="section-head">Why this is a risk</div>
                 <div class="focus-description">${this.escape(selected.description)}</div>
 
-                <div class="section-label">REMEDIATION STRATEGY</div>
+                <div class="section-head">Recommended fix</div>
                 <div class="code-card">
                     <div class="code-meta">
                         <span>${this.escape(this.relativePath(selected.filePath))}</span>
@@ -248,7 +247,7 @@ class ActiveFindingsPanel {
                 </div>
 
                 <button class="primary-action" data-command="copy" data-id="${this.escape(selected.id)}">
-                    ${Sparkles(14)} Apply Fix via Aegis Code
+                    ${Sparkles(14)} Copy Recommended Fix
                 </button>
 
                 <div class="action-grid">
@@ -279,7 +278,7 @@ class ActiveFindingsPanel {
             <div class="empty-state">
                 <div class="empty-icon">${Target(28)}</div>
                 <div class="empty-title">No active findings</div>
-                <div class="empty-copy">Run a scan to populate this panel.</div>
+                <div class="empty-copy-text">Run a scan to populate this panel.</div>
             </div>
         `;
 
@@ -287,391 +286,13 @@ class ActiveFindingsPanel {
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; script-src 'nonce-${nonce}'; ${WEBVIEW_FONT_CSP}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>AegisCode Active Findings</title>
-    <style>
-        @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700;800&display=swap');
-
-        :root {
-            --bg: #0E0D0C;
-            --panel: #1A1714;
-            --panel-2: #201D19;
-            --border: #2E2A26;
-            --border-subtle: rgba(255,255,255,0.04);
-            --copy: #E8E2D9;
-            --copy-dim: #A89F94;
-            --copy-faint: #5C5650;
-            --amber: #FF9D12;
-            --red: #E05A5A;
-            --green: #7A9970;
-            --yellow: #dfc15b;
-            --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", "Consolas", monospace;
-            --font-sans: "Inter", "Segoe UI", -apple-system, sans-serif;
-        }
-
-        * { box-sizing: border-box; margin: 0; padding: 0; }
-
-        body {
-            background: var(--bg);
-            color: var(--copy);
-            font-family: var(--font-sans);
-            font-size: 13px;
-            line-height: 1.5;
-            -webkit-font-smoothing: antialiased;
-        }
-
-        button {
-            font-family: inherit;
-            color: inherit;
-            cursor: pointer;
-            border: none;
-            background: none;
-            outline: none;
-        }
-
-        .shell {
-            min-height: 100vh;
-            padding: 16px 14px 22px;
-        }
-
-        /* ── Header ─────────────────────────────────── */
-        .header {
-            display: flex;
-            align-items: center;
-            justify-content: space-between;
-            margin-bottom: 18px;
-        }
-
-        .header-left {
-            display: flex;
-            align-items: center;
-            gap: 8px;
-        }
-
-        .header-title {
-            font-family: var(--font-mono);
-            color: var(--copy);
-            font-size: 12px;
-            font-weight: 700;
-            letter-spacing: 0.1em;
-            text-transform: uppercase;
-        }
-
-        .count-badge {
-            background: var(--panel-2);
-            border-radius: 4px;
-            padding: 2px 7px;
-            font-family: var(--font-mono);
-            font-size: 11px;
-            font-weight: 700;
-            color: var(--copy-dim);
-        }
-
-        .header-actions {
-            display: flex;
-            gap: 4px;
-        }
-
-        .icon-btn {
-            width: 26px;
-            height: 26px;
-            display: grid;
-            place-items: center;
-            border-radius: 6px;
-            color: var(--copy-dim);
-            transition: all 0.15s ease;
-        }
-
-        .icon-btn:hover {
-            background: rgba(255,255,255,0.06);
-            color: var(--copy);
-        }
-
-        /* ── Focus Card ──────────────────────────────── */
-        .focus-card {
-            background: var(--panel-2);
-            border-left: 3px solid var(--amber);
-            padding: 18px 16px;
-            margin-bottom: 12px;
-        }
-
-        .severity-critical { border-left-color: var(--red); }
-        .severity-high { border-left-color: var(--amber); }
-        .severity-medium { border-left-color: var(--yellow); }
-        .severity-low { border-left-color: var(--green); }
-        .severity-info { border-left-color: #7fa0b7; }
-
-        .focus-head {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            margin-bottom: 8px;
-        }
-
-        .focus-label {
-            font-family: var(--font-mono);
-            font-size: 10px;
-            font-weight: 700;
-            letter-spacing: 0.14em;
-            text-transform: uppercase;
-            display: flex;
-            align-items: center;
-            gap: 6px;
-        }
-
-        .focus-confidence {
-            background: var(--panel);
-            color: var(--copy-dim);
-            padding: 3px 8px;
-            font-family: var(--font-mono);
-            font-size: 11px;
-            font-weight: 700;
-            border-radius: 4px;
-        }
-
-        .focus-title {
-            font-size: 20px;
-            font-weight: 700;
-            line-height: 1.2;
-            color: #f0efec;
-            margin-bottom: 10px;
-        }
-
-        .focus-meta {
-            color: var(--copy-dim);
-            font-family: var(--font-mono);
-            font-size: 11px;
-            font-weight: 500;
-            margin-bottom: 18px;
-            display: flex;
-            align-items: center;
-            gap: 6px;
-        }
-
-        .dot {
-            color: var(--copy-faint);
-            margin: 0 4px;
-        }
-
-        /* ── Section Labels ──────────────────────────── */
-        .section-label {
-            font-family: var(--font-mono);
-            color: var(--copy-faint);
-            font-size: 10px;
-            font-weight: 700;
-            letter-spacing: 0.16em;
-            text-transform: uppercase;
-            margin-bottom: 8px;
-        }
-
-        .focus-description {
-            color: var(--copy);
-            font-size: 13px;
-            line-height: 1.6;
-            margin-bottom: 18px;
-        }
-
-        .focus-description code {
-            font-family: var(--font-mono);
-            background: rgba(255,255,255,0.06);
-            padding: 1px 5px;
-            border-radius: 3px;
-            font-size: 12px;
-            color: var(--amber);
-        }
-
-        /* ── Code Card ───────────────────────────────── */
-        .code-card {
-            background: var(--bg);
-            border: 1px solid var(--border);
-            border-radius: 4px;
-            margin-bottom: 16px;
-            overflow: hidden;
-        }
-
-        .code-meta {
-            display: flex;
-            justify-content: space-between;
-            padding: 8px 12px;
-            border-bottom: 1px solid var(--border);
-            font-family: var(--font-mono);
-            color: var(--copy-faint);
-            font-size: 10px;
-            font-weight: 600;
-        }
-
-        .code-lang {
-            color: var(--copy-dim);
-        }
-
-        .code-block {
-            margin: 0;
-            padding: 14px 12px;
-            white-space: pre-wrap;
-            font-family: var(--font-mono);
-            font-size: 11px;
-            line-height: 1.65;
-            color: var(--copy);
-        }
-
-        /* ── Primary Action Button ───────────────────── */
-        .primary-action {
-            width: 100%;
-            background: var(--amber);
-            color: #1A1000;
-            padding: 14px 12px;
-            font-family: var(--font-mono);
-            font-size: 13px;
-            font-weight: 800;
-            letter-spacing: 0.02em;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 8px;
-            margin-bottom: 10px;
-            transition: all 0.15s ease;
-        }
-
-        .primary-action:hover {
-            background: #FFB040;
-            transform: translateY(-1px);
-            box-shadow: 0 4px 16px rgba(255,157,18,0.25);
-        }
-
-        .primary-action:active {
-            transform: translateY(0);
-        }
-
-        /* ── Action Grid ─────────────────────────────── */
-        .action-grid {
-            display: grid;
-            grid-template-columns: 1fr 1fr;
-            gap: 6px;
-            margin-bottom: 16px;
-        }
-
-        .action-btn {
-            width: 100%;
-            background: var(--panel);
-            color: var(--copy);
-            border: 1px solid var(--border);
-            padding: 10px 10px;
-            font-size: 11px;
-            font-weight: 600;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            gap: 6px;
-            transition: all 0.15s ease;
-        }
-
-        .action-btn:hover {
-            background: var(--panel-2);
-            border-color: var(--copy-faint);
-        }
-
-        /* ── Finding List ────────────────────────────── */
-        .finding-list {
-            display: flex;
-            flex-direction: column;
-            gap: 4px;
-        }
-
-        .finding-item {
-            width: 100%;
-            background: transparent;
-            padding: 12px 10px;
-            text-align: left;
-            border-bottom: 1px solid var(--border-subtle);
-            transition: background 0.12s ease;
-        }
-
-        .finding-item:hover {
-            background: rgba(255,255,255,0.03);
-        }
-
-        .finding-row {
-            display: grid;
-            grid-template-columns: 16px 1fr auto;
-            gap: 10px;
-            align-items: center;
-        }
-
-        .finding-icon {
-            display: flex;
-            align-items: center;
-        }
-
-        .finding-copy {
-            display: flex;
-            flex-direction: column;
-            gap: 2px;
-        }
-
-        .finding-severity {
-            font-family: var(--font-mono);
-            font-size: 9px;
-            font-weight: 700;
-            letter-spacing: 0.1em;
-        }
-
-        .finding-title {
-            color: var(--copy);
-            font-size: 13px;
-            font-weight: 600;
-        }
-
-        .finding-location {
-            font-family: var(--font-mono);
-            color: var(--copy-faint);
-            font-size: 10px;
-            text-align: right;
-        }
-
-        /* ── Empty State ─────────────────────────────── */
-        .empty-state {
-            min-height: 70vh;
-            display: flex;
-            flex-direction: column;
-            align-items: center;
-            justify-content: center;
-            text-align: center;
-        }
-
-        .empty-icon {
-            width: 60px;
-            height: 60px;
-            border-radius: 16px;
-            background: var(--panel-2);
-            display: grid;
-            place-items: center;
-            color: var(--amber);
-            margin-bottom: 18px;
-        }
-
-        .empty-title {
-            font-size: 20px;
-            font-weight: 700;
-            color: #f0eeea;
-            margin-bottom: 8px;
-        }
-
-        .empty-copy {
-            color: var(--copy-dim);
-            font-size: 13px;
-            max-width: 280px;
-        }
-
-        /* ── Scrollbar ───────────────────────────────── */
-        ::-webkit-scrollbar { width: 6px; }
-        ::-webkit-scrollbar-track { background: transparent; }
-        ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
-        ::-webkit-scrollbar-thumb:hover { background: var(--copy-faint); }
-    </style>
+    <style>${buildWebviewStyles("findings")}</style>
 </head>
 <body>
-    <div class="shell">
+    <div class="shell findings-shell">
         <div class="header">
             <div class="header-left">
                 <span class="header-title">Active Findings</span>

--- a/apps/extension/src/ui/aegisSidebarPanel.ts
+++ b/apps/extension/src/ui/aegisSidebarPanel.ts
@@ -1,273 +1,276 @@
-import * as vscode from 'vscode';
-import type { Severity, Vulnerability } from '../api/scanApi';
-import { logger } from '../utils/logger';
+import * as vscode from "vscode";
+import type { Severity, Vulnerability } from "../api/scanApi";
+import { logger } from "../utils/logger";
 import {
-    RefreshCw,
-    X,
-    MoreHorizontal,
-    Play,
-    Square,
-    AlertTriangle,
-    AlertCircle,
-    Info,
-    CheckCircle,
-    ShieldOff,
-    Shield,
-    LogIn,
-    LogOut,
-    RefreshCcw,
-    Monitor,
-    FileCode,
-    FileJson,
-    FileText,
-    FilePy,
-    FileCss,
-    Folder,
-    Braces,
-    Target,
-    Activity,
-    Scan,
-    FileSearch,
-    FolderSearch,
-    Eye,
-    Clock,
-} from './icons';
+  buildWebviewStyles,
+  severityColor as themeSeverityColor,
+  WEBVIEW_FONT_CSP,
+} from "./webviewTheme";
+import {
+  RefreshCw,
+  X,
+  MoreHorizontal,
+  Play,
+  Square,
+  AlertTriangle,
+  AlertCircle,
+  Info,
+  CheckCircle,
+  ShieldOff,
+  LogIn,
+  LogOut,
+  RefreshCcw,
+  Monitor,
+  FileCode,
+  FileJson,
+  FileText,
+  FilePy,
+  FileCss,
+  Folder,
+  Braces,
+  Target,
+  Activity,
+  Scan,
+  FileSearch,
+  FolderSearch,
+  Eye,
+  Clock,
+} from "./icons";
 
 export interface ThreatCounts {
-    critical: number;
-    high: number;
-    medium: number;
-    low: number;
+  critical: number;
+  high: number;
+  medium: number;
+  low: number;
 }
 
 export interface RecentScanItem {
-    filePath: string;
-    status: Severity | 'clean';
-    issueCount: number;
-    scannedAtLabel: string;
+  filePath: string;
+  status: Severity | "clean";
+  issueCount: number;
+  scannedAtLabel: string;
 }
 
 export interface LiveFileItem {
-    filePath: string;
-    issueCount: number;
-    findings: Vulnerability[];
+  filePath: string;
+  issueCount: number;
+  findings: Vulnerability[];
 }
 
 export type AegisSidebarState =
-    | { kind: 'auth' }
-    | {
-          kind: 'offline';
-          code: string;
-          detail: string;
-      }
-    | {
-          kind: 'dashboard';
-          score: number;
-          riskLabel: string;
-          lastRunLabel: string;
-          active: boolean;
-          threatCounts: ThreatCounts;
-          totalIssues: number;
-          recentScans: RecentScanItem[];
-          username?: string;
-          ide?: string;
-      }
-    | {
-          kind: 'watching';
-          activeFile: string;
-          lastRunLabel: string;
-          threatCounts: ThreatCounts;
-          totalIssues: number;
-          liveFiles: LiveFileItem[];
-          username?: string;
-          ide?: string;
-      };
+  | { kind: "auth" }
+  | {
+      kind: "offline";
+      code: string;
+      detail: string;
+    }
+  | {
+      kind: "dashboard";
+      score: number;
+      riskLabel: string;
+      lastRunLabel: string;
+      active: boolean;
+      threatCounts: ThreatCounts;
+      totalIssues: number;
+      recentScans: RecentScanItem[];
+      username?: string;
+      ide?: string;
+    }
+  | {
+      kind: "watching";
+      activeFile: string;
+      lastRunLabel: string;
+      threatCounts: ThreatCounts;
+      totalIssues: number;
+      liveFiles: LiveFileItem[];
+      username?: string;
+      ide?: string;
+    };
 
 type SidebarMessage =
-    | { command: 'signInGithub' }
-    | { command: 'connectServer' }
-    | { command: 'startWatch' }
-    | { command: 'scanFile' }
-    | { command: 'scanWorkspace' }
-    | { command: 'stopWatch' }
-    | { command: 'reconnect' }
-    | { command: 'openServerStatus' }
-    | { command: 'refresh' }
-    | { command: 'openRecent'; filePath: string }
-    | { command: 'showOutput' }
-    | { command: 'logout' };
+  | { command: "signInGithub" }
+  | { command: "connectServer" }
+  | { command: "startWatch" }
+  | { command: "scanFile" }
+  | { command: "scanWorkspace" }
+  | { command: "stopWatch" }
+  | { command: "reconnect" }
+  | { command: "openServerStatus" }
+  | { command: "refresh" }
+  | { command: "openRecent"; filePath: string }
+  | { command: "showOutput" }
+  | { command: "logout" };
 
-const FRONTEND_URL = process.env.FRONTEND_BASE_URL || 'http://localhost:3000';
+const FRONTEND_URL = process.env.FRONTEND_BASE_URL || "http://localhost:3000";
 
 class AegisSidebarPanel implements vscode.WebviewViewProvider {
-    static readonly viewId = 'aegiscode.panel';
+  static readonly viewId = "aegiscode.panel";
 
-    private view?: vscode.WebviewView;
-    private state: AegisSidebarState = { kind: 'auth' };
+  private view?: vscode.WebviewView;
+  private state: AegisSidebarState = { kind: "auth" };
 
-    resolveWebviewView(webviewView: vscode.WebviewView): void {
-        this.view = webviewView;
-        webviewView.webview.options = { enableScripts: true };
-        this.render();
+  resolveWebviewView(webviewView: vscode.WebviewView): void {
+    this.view = webviewView;
+    webviewView.webview.options = { enableScripts: true };
+    this.render();
 
-        webviewView.webview.onDidReceiveMessage(async (message: SidebarMessage) => {
-            logger.info(`Sidebar message: ${message.command}`);
+    webviewView.webview.onDidReceiveMessage(async (message: SidebarMessage) => {
+      logger.info(`Sidebar message: ${message.command}`);
 
-            switch (message.command) {
-                case 'signInGithub':
-                    await vscode.commands.executeCommand('aegiscode.signInGithub');
-                    return;
-                case 'connectServer':
-                    await vscode.commands.executeCommand('aegiscode.login');
-                    return;
-                case 'startWatch':
-                    await vscode.commands.executeCommand('aegiscode.startSession');
-                    return;
-                case 'scanFile':
-                    await vscode.commands.executeCommand('aegiscode.scanNow');
-                    return;
-                case 'scanWorkspace':
-                    await vscode.commands.executeCommand('aegiscode.scanWorkspace');
-                    return;
-                case 'stopWatch':
-                    await vscode.commands.executeCommand('aegiscode.stopSession');
-                    return;
-                case 'reconnect':
-                    await vscode.commands.executeCommand('aegiscode.login');
-                    return;
-                case 'openServerStatus':
-                    logger.show();
-                    return;
-                case 'refresh':
-                    this.render();
-                    return;
-                case 'openRecent': {
-                    if (!message.filePath) return;
-                    try {
-                        const document = await vscode.workspace.openTextDocument(message.filePath);
-                        await vscode.window.showTextDocument(document, { preview: false, viewColumn: vscode.ViewColumn.One });
-                    } catch {
-                        void vscode.window.showWarningMessage('AegisCode: Unable to open that file.');
-                    }
-                    return;
-                }
-                case 'showOutput':
-                    logger.show();
-                    return;
-                case 'logout':
-                    await vscode.commands.executeCommand('aegiscode.logout');
-                    return;
-            }
-        });
-    }
-
-    setState(state: AegisSidebarState): void {
-        this.state = state;
-        this.render();
-    }
-
-    getState(): AegisSidebarState {
-        return this.state;
-    }
-
-    private render(): void {
-        if (!this.view) {
-            return;
+      switch (message.command) {
+        case "signInGithub":
+          await vscode.commands.executeCommand("aegiscode.signInGithub");
+          return;
+        case "connectServer":
+          await vscode.commands.executeCommand("aegiscode.login");
+          return;
+        case "startWatch":
+          await vscode.commands.executeCommand("aegiscode.startSession");
+          return;
+        case "scanFile":
+          await vscode.commands.executeCommand("aegiscode.scanNow");
+          return;
+        case "scanWorkspace":
+          await vscode.commands.executeCommand("aegiscode.scanWorkspace");
+          return;
+        case "stopWatch":
+          await vscode.commands.executeCommand("aegiscode.stopSession");
+          return;
+        case "reconnect":
+          await vscode.commands.executeCommand("aegiscode.login");
+          return;
+        case "openServerStatus":
+          logger.show();
+          return;
+        case "refresh":
+          this.render();
+          return;
+        case "openRecent": {
+          if (!message.filePath) return;
+          try {
+            const document = await vscode.workspace.openTextDocument(
+              message.filePath,
+            );
+            await vscode.window.showTextDocument(document, {
+              preview: false,
+              viewColumn: vscode.ViewColumn.One,
+            });
+          } catch {
+            void vscode.window.showWarningMessage(
+              "AegisCode: Unable to open that file.",
+            );
+          }
+          return;
         }
+        case "showOutput":
+          logger.show();
+          return;
+        case "logout":
+          await vscode.commands.executeCommand("aegiscode.logout");
+          return;
+      }
+    });
+  }
 
-        this.view.webview.html = this.buildHtml(this.state);
+  setState(state: AegisSidebarState): void {
+    this.state = state;
+    this.render();
+  }
+
+  getState(): AegisSidebarState {
+    return this.state;
+  }
+
+  private render(): void {
+    if (!this.view) {
+      return;
     }
 
-    private nonce(): string {
-        return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    }
+    this.view.webview.html = this.buildHtml(this.state);
+  }
 
-    private escape(value: string): string {
-        return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-    }
+  private nonce(): string {
+    return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  }
 
-    private basename(filePath: string): string {
-        return filePath.replace(/\\/g, '/').split('/').pop() || filePath;
-    }
+  private escape(value: string): string {
+    return value
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;");
+  }
 
-    private relativePath(filePath: string): string {
-        const parts = filePath.replace(/\\/g, '/').split('/');
-        return parts.slice(-3).join('/');
-    }
+  private basename(filePath: string): string {
+    return filePath.replace(/\\/g, "/").split("/").pop() || filePath;
+  }
 
-    private severityColor(severity: Severity | 'clean'): string {
-        switch (severity) {
-            case 'critical':
-                return '#E05A5A';
-            case 'high':
-                return '#ff9d12';
-            case 'medium':
-                return '#dfc15b';
-            case 'clean':
-            case 'low':
-                return '#7A9970';
-            default:
-                return '#7fa0b7';
+  private relativePath(filePath: string): string {
+    const parts = filePath.replace(/\\/g, "/").split("/");
+    return parts.slice(-3).join("/");
+  }
+
+  private severityColor(severity: Severity | "clean"): string {
+    return themeSeverityColor(severity);
+  }
+
+  private severityIcon(severity: Severity | "clean", size = 16): string {
+    const color = this.severityColor(severity);
+    switch (severity) {
+      case "critical":
+        return `<span style="color:${color}">${AlertTriangle(size)}</span>`;
+      case "high":
+        return `<span style="color:${color}">${AlertCircle(size)}</span>`;
+      case "medium":
+        return `<span style="color:${color}">${Info(size)}</span>`;
+      case "clean":
+      case "low":
+        return `<span style="color:${color}">${CheckCircle(size)}</span>`;
+      default:
+        return `<span style="color:${color}">${Info(size)}</span>`;
+    }
+  }
+
+  private fileIcon(filePath: string): string {
+    const ext = this.basename(filePath).split(".").pop()?.toLowerCase();
+    switch (ext) {
+      case "ts":
+      case "tsx":
+        return `<span class="file-icon" style="color:#3178C6">${FileCode(14)}</span>`;
+      case "js":
+      case "jsx":
+        return `<span class="file-icon js">${FileCode(14)}</span>`;
+      case "py":
+        return `<span class="file-icon py">${FilePy(14)}</span>`;
+      case "css":
+      case "scss":
+        return `<span class="file-icon css">${FileCss(14)}</span>`;
+      case "yml":
+      case "yaml":
+      case "json":
+        return `<span class="file-icon json">${Braces(14)}</span>`;
+      default:
+        if (filePath.endsWith("/") || !ext) {
+          return `<span class="file-icon folder">${Folder(14)}</span>`;
         }
+        return `<span class="file-icon">${FileText(14)}</span>`;
     }
+  }
 
-    private severityIcon(severity: Severity | 'clean', size = 16): string {
-        switch (severity) {
-            case 'critical':
-                return `<span style="color:#E05A5A">${AlertTriangle(size)}</span>`;
-            case 'high':
-                return `<span style="color:#ff9d12">${AlertCircle(size)}</span>`;
-            case 'medium':
-                return `<span style="color:#dfc15b">${Info(size)}</span>`;
-            case 'clean':
-            case 'low':
-                return `<span style="color:#7A9970">${CheckCircle(size)}</span>`;
-            default:
-                return `<span style="color:#7fa0b7">${Info(size)}</span>`;
-        }
-    }
+  private riskTone(score: number): string {
+    if (score <= 3.5) return "critical";
+    if (score <= 6.0) return "high";
+    if (score <= 8.0) return "medium";
+    return "low";
+  }
 
-    private fileIcon(filePath: string): string {
-        const ext = this.basename(filePath).split('.').pop()?.toLowerCase();
-        switch (ext) {
-            case 'ts':
-            case 'tsx':
-                return `<span class="file-icon" style="color:#3178C6">${FileCode(14)}</span>`;
-            case 'js':
-            case 'jsx':
-                return `<span class="file-icon js">${FileCode(14)}</span>`;
-            case 'py':
-                return `<span class="file-icon py">${FilePy(14)}</span>`;
-            case 'css':
-            case 'scss':
-                return `<span class="file-icon css">${FileCss(14)}</span>`;
-            case 'yml':
-            case 'yaml':
-            case 'json':
-                return `<span class="file-icon json">${Braces(14)}</span>`;
-            default:
-                if (filePath.endsWith('/') || !ext) {
-                    return `<span class="file-icon folder">${Folder(14)}</span>`;
-                }
-                return `<span class="file-icon">${FileText(14)}</span>`;
-        }
-    }
+  private buildHtml(state: AegisSidebarState): string {
+    const nonce = this.nonce();
 
-    private riskTone(score: number): string {
-        if (score <= 3.5) return 'critical';
-        if (score <= 6.0) return 'high';
-        if (score <= 8.0) return 'medium';
-        return 'low';
-    }
-
-    private buildHtml(state: AegisSidebarState): string {
-        const nonce = this.nonce();
-
-        return `<!DOCTYPE html>
+    return `<!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; script-src 'nonce-${nonce}'; font-src https://fonts.gstatic.com https://fonts.googleapis.com;">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline' https://fonts.googleapis.com; script-src 'nonce-${nonce}'; ${WEBVIEW_FONT_CSP}">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <style>${this.styles()}</style>
 </head>
@@ -309,21 +312,24 @@ class AegisSidebarPanel implements vscode.WebviewViewProvider {
     </script>
 </body>
 </html>`;
-    }
+  }
 
-    private topbar(state: AegisSidebarState): string {
-        const showBadge =
-            state.kind === 'dashboard' && state.active
-                ? '<span class="status-badge active">● ACTIVE</span>'
-                : state.kind === 'watching'
-                ? '<span class="status-badge watching">● WATCHING</span>'
-                : '';
-        const isAuthed = state.kind !== 'auth';
+  private topbar(state: AegisSidebarState): string {
+    const showBadge =
+      state.kind === "dashboard" && state.active
+        ? '<span class="status-badge active">● ACTIVE</span>'
+        : state.kind === "watching"
+          ? '<span class="status-badge watching">● WATCHING</span>'
+          : "";
+    const isAuthed = state.kind !== "auth";
 
-        return `
+    return `
             <div class="topbar">
                 <div class="brand-row">
-                    <span class="brand-text">AEGIS CODE</span>
+                    <div>
+                        <div class="brand-wordmark">AegisCode</div>
+                        <div class="brand-sub">security guardian</div>
+                    </div>
                     ${showBadge}
                 </div>
                 <div class="top-actions">
@@ -334,50 +340,55 @@ class AegisSidebarPanel implements vscode.WebviewViewProvider {
                         <div class="dropdown-menu" id="dropdownMenu">
                             <button class="dropdown-item" data-command="showOutput">${Monitor(12)} Show Output</button>
                             <button class="dropdown-item" data-command="refresh">${RefreshCw(12)} Refresh</button>
-                            ${isAuthed ? `<div class="dropdown-sep"></div><button class="dropdown-item danger" data-command="logout">${LogOut(12)} Sign Out</button>` : ''}
+                            ${isAuthed ? `<div class="dropdown-sep"></div><button class="dropdown-item danger" data-command="logout">${LogOut(12)} Sign Out</button>` : ""}
                         </div>
                     </div>
                 </div>
             </div>
         `;
-    }
+  }
 
-    private body(state: AegisSidebarState): string {
-        switch (state.kind) {
-            case 'auth':
-                return this.authBody();
-            case 'offline':
-                return this.offlineBody(state);
-            case 'watching':
-                return this.watchingBody(state);
-            case 'dashboard':
-            default:
-                return this.dashboardBody(state);
-        }
+  private body(state: AegisSidebarState): string {
+    switch (state.kind) {
+      case "auth":
+        return this.authBody();
+      case "offline":
+        return this.offlineBody(state);
+      case "watching":
+        return this.watchingBody(state);
+      case "dashboard":
+      default:
+        return this.dashboardBody(state);
     }
+  }
 
-    private authBody(): string {
-        return `
+  private authBody(): string {
+    return `
             <div class="center-panel">
-                <div class="center-icon shield">${Shield(32)}</div>
-                <div class="hero-title">Authentication Required</div>
-                <div class="hero-copy">Connect your account to access<br>Aegis Code security telemetry<br>and scan controls.</div>
+                <div class="wordmark-block">
+                    <span class="wordmark">AegisCode</span>
+                    <span class="descriptor">security guardian</span>
+                </div>
+                <div class="hero-title">Access your workspace.</div>
+                <div class="hero-copy">Sign in to start real-time security scanning and sync telemetry with your command center.</div>
                 <div class="btn-stack">
                     <button class="primary-btn" data-command="signInGithub">${LogIn(14)} Sign in with GitHub</button>
-                    <button class="secondary-btn" data-command="connectServer">${RefreshCcw(14)} Connect to Server</button>
+                    <button class="secondary-btn" data-command="connectServer">${RefreshCcw(14)} Enter API Token</button>
                     <button class="text-btn" data-command="showOutput">${Monitor(12)} Check server status</button>
                 </div>
             </div>
-            <div class="footer-status">● AWAITING CONNECTION</div>
+            <div class="footer-status">● Awaiting connection</div>
         `;
-    }
+  }
 
-    private offlineBody(state: Extract<AegisSidebarState, { kind: 'offline' }>): string {
-        return `
+  private offlineBody(
+    state: Extract<AegisSidebarState, { kind: "offline" }>,
+  ): string {
+    return `
             <div class="center-panel">
                 <div class="center-icon offline">${ShieldOff(32)}</div>
-                <div class="hero-title">Backend Offline</div>
-                <div class="hero-copy">Connection to<br>AEGIS_CODE lost.<br>Authentication token may<br>have expired.</div>
+                <div class="hero-title">Backend offline</div>
+                <div class="hero-copy">Connection to the AegisCode server was lost. Your session token may have expired.</div>
                 <div class="error-box">
                     <div class="error-code">${AlertCircle(12)} ${this.escape(state.code)}</div>
                     <div class="error-detail">${this.escape(state.detail)}</div>
@@ -389,22 +400,36 @@ class AegisSidebarPanel implements vscode.WebviewViewProvider {
                 </div>
             </div>
         `;
-    }
+  }
 
-    private dashboardBody(state: Extract<AegisSidebarState, { kind: 'dashboard' }>): string {
-        const tone = this.riskTone(state.score);
-        const riskScore = Math.max(0, Math.round((10 - state.score) * 10));
+  private dashboardBody(
+    state: Extract<AegisSidebarState, { kind: "dashboard" }>,
+  ): string {
+    const tone = this.riskTone(state.score);
+    const riskScore = Math.max(0, Math.round((10 - state.score) * 10));
 
-        const threats = [
-            { label: 'CRITICAL', value: state.threatCounts.critical, severity: 'critical' as const },
-            { label: 'HIGH', value: state.threatCounts.high, severity: 'high' as const },
-            { label: 'MEDIUM', value: state.threatCounts.medium, severity: 'medium' as const },
-            { label: 'LOW', value: state.threatCounts.low, severity: 'low' as const },
-        ];
+    const threats = [
+      {
+        label: "CRITICAL",
+        value: state.threatCounts.critical,
+        severity: "critical" as const,
+      },
+      {
+        label: "HIGH",
+        value: state.threatCounts.high,
+        severity: "high" as const,
+      },
+      {
+        label: "MEDIUM",
+        value: state.threatCounts.medium,
+        severity: "medium" as const,
+      },
+      { label: "LOW", value: state.threatCounts.low, severity: "low" as const },
+    ];
 
-        const threatCards = threats
-            .map(
-                (item) => `
+    const threatCards = threats
+      .map(
+        (item) => `
                 <div class="threat-card">
                     <div class="threat-label">${item.label}</div>
                     <div class="threat-row">
@@ -413,64 +438,77 @@ class AegisSidebarPanel implements vscode.WebviewViewProvider {
                     </div>
                 </div>
             `,
-            )
-            .join('');
+      )
+      .join("");
 
-        const recent = state.recentScans.length
-            ? state.recentScans
-                  .map(
-                      (item) => `
+    const recent = state.recentScans.length
+      ? state.recentScans
+          .map(
+            (item) => `
                     <button class="recent-row" data-command="openRecent" data-file-path="${this.escape(item.filePath)}">
                         ${this.fileIcon(item.filePath)}
                         <span class="recent-file">${this.escape(this.relativePath(item.filePath))}</span>
                         <span class="recent-state">${this.severityIcon(item.status, 16)}</span>
                     </button>
                 `,
-                  )
-                  .join('')
-            : '<div class="empty-copy">Run a scan to populate recent activity.</div>';
+          )
+          .join("")
+      : '<div class="empty-copy">Run a scan to populate recent activity.</div>';
 
-        const issueSummaryRows = [
-            { label: 'Critical', value: state.threatCounts.critical, color: '#E05A5A' },
-            { label: 'High', value: state.threatCounts.high, color: '#ff9d12' },
-        ];
+    const issueSummaryRows = [
+      {
+        label: "Critical",
+        value: state.threatCounts.critical,
+        color: themeSeverityColor("critical"),
+      },
+      {
+        label: "High",
+        value: state.threatCounts.high,
+        color: themeSeverityColor("high"),
+      },
+    ];
 
-        const issueRows = issueSummaryRows
-            .map(
-                (row) => `
+    const issueRows = issueSummaryRows
+      .map(
+        (row) => `
                 <div class="issue-row">
                     <span class="issue-dot" style="background:${row.color}"></span>
                     <span class="issue-label">${row.label}</span>
                     <span class="issue-value" style="color:${row.color}">${row.value}</span>
                 </div>
             `,
-            )
-            .join('');
+      )
+      .join("");
 
-        return `
+    return `
             <div class="meta-strip">
-                <span>AEGIS_CODE</span>
-                <span class="status-badge-inline ${state.active ? 'active' : ''}">${state.active ? '● ACTIVE' : '○ IDLE'}</span>
+                <span>Command Center</span>
+                <span class="status-badge-inline ${state.active ? "active" : ""}">${state.active ? "● Active" : "○ Idle"}</span>
             </div>
             <div class="meta-strip sub">
-                <span>V2.0.48_STABLE</span>
-                <span>L_SCAN: ${this.escape(state.lastRunLabel)}</span>
+                <span>${this.escape(state.ide || "IDE")}</span>
+                <span>Last scan: ${this.escape(state.lastRunLabel)}</span>
             </div>
-            ${state.username ? `
+            ${
+              state.username
+                ? `
             <div class="user-strip">
                 <div class="user-info">
                     <span class="user-avatar">${this.escape(state.username[0].toUpperCase())}</span>
-                    <span class="user-name">@${this.escape(state.username)}</span>
+                    <span class="user-name">${this.escape(state.username)}</span>
                 </div>
                 <div class="user-actions">
+                    ${state.ide ? `<span class="ide-badge">${Monitor(10)} ${this.escape(state.ide)}</span>` : ""}
                     <button class="logout-btn" data-command="logout" title="Sign out">${LogOut(12)}</button>
                 </div>
             </div>
-            ` : ''}
+            `
+                : ""
+            }
 
             <div class="summary-card">
                 <div class="summary-left">
-                    <div class="section-head">PROJECT RISK</div>
+                    <div class="section-head">Global Health Index</div>
                     <div class="score-row">
                         <span class="score-value">${riskScore}</span>
                         <span class="score-max">/100</span>
@@ -503,22 +541,24 @@ class AegisSidebarPanel implements vscode.WebviewViewProvider {
                     <button class="secondary-btn compact" data-command="scanFile">${FileSearch(13)} Scan File</button>
                     <button class="secondary-btn compact" data-command="scanWorkspace">${FolderSearch(13)} Scan Workspace</button>
                 </div>
-                <button class="primary-btn watch-btn" data-command="startWatch">${Eye(14)} ${state.active ? 'WATCH MODE ACTIVE' : 'START WATCH MODE'}</button>
+                <button class="primary-btn watch-btn" data-command="startWatch">${Eye(14)} ${state.active ? "WATCH MODE ACTIVE" : "START WATCH MODE"}</button>
                 <div class="footer-meta">
                     <span>Last run: ${this.escape(state.lastRunLabel)}</span>
-                    <span class="${state.active ? 'online' : 'idle'}">● ${state.active ? 'Engine Active' : 'Engine Idle'}</span>
+                    <span class="${state.active ? "online" : "idle"}">● ${state.active ? "Engine Active" : "Engine Idle"}</span>
                 </div>
             </div>
         `;
-    }
+  }
 
-    private watchingBody(state: Extract<AegisSidebarState, { kind: 'watching' }>): string {
-        const files = state.liveFiles.length
-            ? state.liveFiles
-                  .map((file) => {
-                      const findings = file.findings
-                          .map(
-                              (finding) => `
+  private watchingBody(
+    state: Extract<AegisSidebarState, { kind: "watching" }>,
+  ): string {
+    const files = state.liveFiles.length
+      ? state.liveFiles
+          .map((file) => {
+            const findings = file.findings
+              .map(
+                (finding) => `
                             <div class="watch-card watch-${finding.severity}">
                                 <div class="watch-head">
                                     <span class="watch-icon">${this.severityIcon(finding.severity, 14)}</span>
@@ -529,42 +569,47 @@ class AegisSidebarPanel implements vscode.WebviewViewProvider {
                                 <div class="watch-meta">Line ${finding.line} <span class="watch-sep">|</span> Rule: ${this.escape(finding.ruleId)}</div>
                             </div>
                         `,
-                          )
-                          .join('');
+              )
+              .join("");
 
-                      return `
+            return `
                         <div class="watch-file">
                             <div class="watch-file-head">
                                 <span>${this.escape(this.relativePath(file.filePath))}</span>
-                                <span class="watch-count">${file.issueCount} ${file.issueCount === 1 ? 'Issue' : 'Issues'}</span>
+                                <span class="watch-count">${file.issueCount} ${file.issueCount === 1 ? "Issue" : "Issues"}</span>
                             </div>
                             ${findings}
                         </div>
                     `;
-                  })
-                  .join('')
-            : '<div class="empty-copy">Watching for file changes and live findings.</div>';
+          })
+          .join("")
+      : '<div class="empty-copy">Watching for file changes and live findings.</div>';
 
-        return `
+    return `
             <div class="watching-head">
                 <div class="live-indicator">
                     <span class="live-dot"></span>
                     <span class="section-head muted">LIVE ANALYSIS</span>
                     ${Activity(14)}
                 </div>
-                <div class="live-line">${Scan(14)} scanning ${this.escape(this.basename(state.activeFile || 'workspace'))}...</div>
+                <div class="live-line">${Scan(14)} scanning ${this.escape(this.basename(state.activeFile || "workspace"))}...</div>
             </div>
-            ${state.username ? `
+            ${
+              state.username
+                ? `
             <div class="user-strip">
                 <div class="user-info">
                     <span class="user-avatar">${this.escape(state.username[0].toUpperCase())}</span>
-                    <span class="user-name">@${this.escape(state.username)}</span>
+                    <span class="user-name">${this.escape(state.username)}</span>
                 </div>
                 <div class="user-actions">
+                    ${state.ide ? `<span class="ide-badge">${Monitor(10)} ${this.escape(state.ide)}</span>` : ""}
                     <button class="logout-btn" data-command="logout" title="Sign out">${LogOut(12)}</button>
                 </div>
             </div>
-            ` : ''}
+            `
+                : ""
+            }
             <div class="watching-stack">${files}</div>
             <div class="footer-panel">
                 <button class="primary-btn scan-btn" data-command="scanWorkspace">${Play(14)} SCAN WORKSPACE</button>
@@ -578,869 +623,11 @@ class AegisSidebarPanel implements vscode.WebviewViewProvider {
                 </div>
             </div>
         `;
-    }
-
-    private styles(): string {
-        return `
-            @import url('https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700;800&family=Inter:wght@400;500;600;700;800&display=swap');
-
-            :root {
-                --bg: #0E0D0C;
-                --bg-2: #151412;
-                --panel: #1A1714;
-                --panel-2: #201D19;
-                --border: #2E2A26;
-                --border-subtle: rgba(255,255,255,0.04);
-                --copy: #E8E2D9;
-                --copy-dim: #A89F94;
-                --copy-faint: #5C5650;
-                --amber: #FF9D12;
-                --amber-dark: #C4701F;
-                --red: #E05A5A;
-                --red-soft: #ffb2b0;
-                --green: #7A9970;
-                --green-soft: #bde5b0;
-                --yellow: #dfc15b;
-                --font-mono: "JetBrains Mono", "Fira Code", "Cascadia Code", "IBM Plex Mono", "Menlo", "Consolas", monospace;
-                --font-sans: "Inter", "Segoe UI", -apple-system, BlinkMacSystemFont, sans-serif;
-            }
-
-            * { box-sizing: border-box; margin: 0; padding: 0; }
-
-            body {
-                background: var(--bg);
-                color: var(--copy);
-                font-family: var(--font-sans);
-                font-size: 12px;
-                line-height: 1.5;
-                -webkit-font-smoothing: antialiased;
-                -moz-osx-font-smoothing: grayscale;
-            }
-
-            button {
-                font-family: inherit;
-                color: inherit;
-                cursor: pointer;
-                border: none;
-                background: none;
-                outline: none;
-            }
-
-            .shell {
-                min-height: 100vh;
-                display: flex;
-                flex-direction: column;
-            }
-
-            .topbar {
-                height: 48px;
-                display: flex;
-                align-items: center;
-                justify-content: space-between;
-                padding: 0 12px;
-                border-bottom: 1px solid var(--border-subtle);
-                background: rgba(0,0,0,0.2);
-            }
-
-            .brand-row {
-                display: flex;
-                align-items: center;
-                gap: 10px;
-            }
-
-            .brand-text {
-                font-family: var(--font-mono);
-                font-size: 13px;
-                font-weight: 800;
-                letter-spacing: 0.14em;
-                color: var(--amber);
-                text-transform: uppercase;
-            }
-
-            .status-badge {
-                display: inline-flex;
-                align-items: center;
-                gap: 4px;
-                padding: 2px 8px;
-                border-radius: 99px;
-                font-family: var(--font-mono);
-                font-size: 9px;
-                font-weight: 700;
-                letter-spacing: 0.1em;
-            }
-
-            .status-badge.active {
-                background: rgba(122,153,112,0.12);
-                color: var(--green-soft);
-                border: 1px solid rgba(122,153,112,0.25);
-            }
-
-            .status-badge.watching {
-                background: rgba(255,157,18,0.1);
-                color: var(--amber);
-                border: 1px solid rgba(255,157,18,0.25);
-            }
-
-            .top-actions {
-                display: flex;
-                gap: 2px;
-            }
-
-            .icon-btn {
-                width: 28px;
-                height: 28px;
-                display: grid;
-                place-items: center;
-                border-radius: 6px;
-                color: var(--copy-dim);
-                transition: all 0.15s ease;
-            }
-
-            .icon-btn:hover {
-                background: rgba(255,255,255,0.06);
-                color: var(--copy);
-            }
-
-            .content {
-                flex: 1;
-                padding: 16px 12px 18px;
-                display: flex;
-                flex-direction: column;
-                gap: 16px;
-            }
-
-            .center-panel {
-                margin: auto 0;
-                padding: 28px 16px 24px;
-                text-align: center;
-            }
-
-            .center-icon {
-                width: 64px;
-                height: 64px;
-                margin: 0 auto 20px;
-                border-radius: 16px;
-                display: grid;
-                place-items: center;
-            }
-
-            .center-icon.shield {
-                background: #282522;
-                color: var(--amber);
-            }
-
-            .center-icon.offline {
-                background: #331617;
-                color: var(--red-soft);
-            }
-
-            .hero-title {
-                font-size: 18px;
-                font-weight: 700;
-                color: var(--copy);
-                margin-bottom: 10px;
-            }
-
-            .hero-copy {
-                color: var(--copy-dim);
-                font-size: 13px;
-                line-height: 1.6;
-                margin-bottom: 20px;
-            }
-
-            .error-box {
-                background: rgba(255,255,255,0.03);
-                border: 1px solid rgba(255,255,255,0.05);
-                border-radius: 8px;
-                padding: 12px 14px;
-                text-align: left;
-                margin-bottom: 20px;
-            }
-
-            .error-code {
-                color: var(--red-soft);
-                font-family: var(--font-mono);
-                font-size: 11px;
-                font-weight: 700;
-                margin-bottom: 6px;
-                display: flex;
-                align-items: center;
-                gap: 6px;
-            }
-
-            .error-detail {
-                color: var(--copy-faint);
-                font-size: 11px;
-                line-height: 1.5;
-            }
-
-            .btn-stack {
-                display: flex;
-                flex-direction: column;
-                gap: 8px;
-            }
-
-            .footer-status {
-                text-align: center;
-                color: var(--copy-faint);
-                font-family: var(--font-mono);
-                font-size: 10px;
-                letter-spacing: 0.18em;
-                padding: 8px 0;
-            }
-
-            .primary-btn {
-                width: 100%;
-                background: var(--amber);
-                color: #1A1000;
-                padding: 14px 12px;
-                font-size: 13px;
-                font-weight: 800;
-                font-family: var(--font-mono);
-                letter-spacing: 0.06em;
-                text-transform: uppercase;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                gap: 8px;
-                transition: all 0.15s ease;
-                border: none;
-            }
-
-            .primary-btn:hover {
-                background: #FFB040;
-                transform: translateY(-1px);
-                box-shadow: 0 4px 16px rgba(255,157,18,0.25);
-            }
-
-            .primary-btn:active {
-                transform: translateY(0);
-            }
-
-            .primary-btn.watch-btn {
-                background: transparent;
-                border: 1px solid var(--border);
-                color: var(--copy);
-                font-size: 12px;
-                padding: 12px;
-            }
-
-            .primary-btn.watch-btn:hover {
-                background: var(--panel-2);
-                box-shadow: none;
-            }
-
-            .secondary-btn {
-                width: 100%;
-                background: transparent;
-                color: var(--copy);
-                border: 1px solid var(--border);
-                padding: 12px;
-                font-size: 12px;
-                font-weight: 600;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                gap: 6px;
-                transition: all 0.15s ease;
-            }
-
-            .secondary-btn:hover {
-                background: var(--panel-2);
-                border-color: var(--copy-faint);
-            }
-
-            .secondary-btn.compact {
-                padding: 10px 8px;
-                font-size: 11px;
-            }
-
-            .text-btn {
-                width: 100%;
-                padding: 8px 12px;
-                color: var(--copy-dim);
-                font-size: 12px;
-                display: flex;
-                align-items: center;
-                justify-content: center;
-                gap: 6px;
-                transition: color 0.15s ease;
-            }
-
-            .text-btn:hover {
-                color: var(--copy);
-            }
-
-            .meta-strip {
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                color: var(--copy-faint);
-                font-family: var(--font-mono);
-                font-size: 10px;
-                font-weight: 600;
-                letter-spacing: 0.08em;
-            }
-
-            .meta-strip.sub {
-                margin-top: -10px;
-                font-size: 9px;
-                color: var(--copy-faint);
-                opacity: 0.7;
-            }
-
-            .status-badge-inline {
-                font-family: var(--font-mono);
-                font-size: 9px;
-                font-weight: 700;
-                letter-spacing: 0.1em;
-                padding: 2px 8px;
-                border-radius: 99px;
-                border: 1px solid var(--border);
-                color: var(--copy-faint);
-            }
-
-            .status-badge-inline.active {
-                background: rgba(122,153,112,0.1);
-                color: var(--green-soft);
-                border-color: rgba(122,153,112,0.3);
-            }
-
-            .summary-card {
-                display: flex;
-                justify-content: space-between;
-                align-items: stretch;
-                gap: 10px;
-                background: var(--panel);
-                border: 1px solid var(--border);
-                padding: 16px;
-            }
-
-            .summary-left {
-                display: flex;
-                flex-direction: column;
-            }
-
-            .section-head {
-                font-family: var(--font-mono);
-                color: var(--copy-dim);
-                font-size: 10px;
-                font-weight: 700;
-                letter-spacing: 0.14em;
-                text-transform: uppercase;
-                margin-bottom: 6px;
-            }
-
-            .score-row {
-                display: flex;
-                align-items: flex-end;
-                gap: 2px;
-            }
-
-            .score-value {
-                font-family: var(--font-mono);
-                font-size: 42px;
-                line-height: 1;
-                font-weight: 800;
-                color: var(--red-soft);
-            }
-
-            .score-max {
-                font-family: var(--font-mono);
-                color: var(--copy-faint);
-                font-size: 13px;
-                font-weight: 700;
-                margin-bottom: 6px;
-            }
-
-            .risk-pill {
-                min-width: 90px;
-                background: var(--panel-2);
-                border: 1px solid var(--border);
-                padding: 10px 12px;
-                display: flex;
-                flex-direction: column;
-                justify-content: space-between;
-                align-items: flex-end;
-            }
-
-            .risk-label-text {
-                font-family: var(--font-mono);
-                font-size: 11px;
-                font-weight: 800;
-                letter-spacing: 0.12em;
-                text-transform: uppercase;
-            }
-
-            .risk-icon {
-                margin-top: 8px;
-            }
-
-            .risk-critical { color: var(--red-soft); }
-            .risk-high { color: var(--amber); }
-            .risk-medium { color: var(--yellow); }
-            .risk-low { color: var(--green-soft); }
-
-            .section-title {
-                font-family: var(--font-mono);
-                color: var(--copy);
-                font-size: 12px;
-                font-weight: 800;
-                letter-spacing: 0.12em;
-                text-transform: uppercase;
-                display: flex;
-                align-items: center;
-                gap: 8px;
-                padding-top: 6px;
-            }
-
-            .threat-grid {
-                display: grid;
-                grid-template-columns: 1fr 1fr;
-                gap: 6px;
-            }
-
-            .threat-card {
-                background: var(--panel);
-                border: 1px solid var(--border-subtle);
-                padding: 12px;
-                min-height: 80px;
-                display: flex;
-                flex-direction: column;
-                justify-content: space-between;
-            }
-
-            .threat-label {
-                font-family: var(--font-mono);
-                color: var(--copy);
-                font-size: 11px;
-                font-weight: 700;
-                text-transform: uppercase;
-                letter-spacing: 0.06em;
-                margin-bottom: 14px;
-            }
-
-            .threat-row {
-                display: flex;
-                align-items: flex-end;
-                justify-content: space-between;
-            }
-
-            .threat-value {
-                font-family: var(--font-mono);
-                font-size: 24px;
-                line-height: 1;
-                font-weight: 800;
-            }
-
-            .recent-list {
-                display: flex;
-                flex-direction: column;
-                gap: 2px;
-            }
-
-            .recent-row {
-                width: 100%;
-                display: grid;
-                grid-template-columns: 22px 1fr auto;
-                gap: 10px;
-                align-items: center;
-                padding: 10px 4px;
-                background: transparent;
-                border: none;
-                cursor: pointer;
-                text-align: left;
-                transition: background 0.12s ease;
-            }
-
-            .recent-row:hover {
-                background: rgba(255,255,255,0.03);
-            }
-
-            .file-icon {
-                display: flex;
-                align-items: center;
-                color: var(--copy-dim);
-            }
-
-            .file-icon.js { color: #F0DB4F; }
-            .file-icon.py { color: #3572A5; }
-            .file-icon.css { color: #563D7C; }
-            .file-icon.json { color: var(--amber-dark); }
-            .file-icon.folder { color: var(--amber); }
-
-            .recent-file {
-                font-family: var(--font-sans);
-                color: var(--copy);
-                font-size: 13px;
-                font-weight: 500;
-                overflow: hidden;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-            }
-
-            .recent-state {
-                display: flex;
-                align-items: center;
-            }
-
-            .issue-section {
-                border: 1px solid var(--border);
-                padding: 14px;
-                margin-top: 4px;
-            }
-
-            .issue-row {
-                display: flex;
-                align-items: center;
-                padding: 8px 0;
-                border-bottom: 1px solid var(--border-subtle);
-            }
-
-            .issue-row:last-child {
-                border-bottom: none;
-            }
-
-            .issue-row.total {
-                border-top: 1px solid var(--border);
-                margin-top: 4px;
-                padding-top: 10px;
-            }
-
-            .issue-dot {
-                width: 6px;
-                height: 6px;
-                border-radius: 50%;
-                margin-right: 10px;
-                flex-shrink: 0;
-            }
-
-            .issue-label {
-                flex: 1;
-                font-size: 12px;
-                color: var(--copy);
-            }
-
-            .issue-value {
-                font-family: var(--font-mono);
-                font-size: 13px;
-                font-weight: 700;
-                color: var(--copy);
-            }
-
-            .empty-copy {
-                color: var(--copy-faint);
-                font-size: 12px;
-                font-style: italic;
-                text-align: center;
-                padding: 16px 0;
-            }
-
-            .footer-panel {
-                margin-top: auto;
-                padding-top: 12px;
-                display: flex;
-                flex-direction: column;
-                gap: 8px;
-            }
-
-            .split-actions {
-                display: grid;
-                grid-template-columns: 1fr 1fr;
-                gap: 6px;
-            }
-
-            .footer-meta {
-                display: flex;
-                justify-content: space-between;
-                gap: 12px;
-                font-family: var(--font-mono);
-                color: var(--copy-faint);
-                font-size: 10px;
-                padding-top: 4px;
-            }
-
-            .online { color: var(--green-soft); }
-            .idle { color: var(--copy-faint); }
-
-            .watching-head {
-                padding-top: 4px;
-            }
-
-            .live-indicator {
-                display: flex;
-                align-items: center;
-                gap: 8px;
-                margin-bottom: 4px;
-            }
-
-            .live-dot {
-                width: 8px;
-                height: 8px;
-                border-radius: 50%;
-                background: var(--amber);
-                box-shadow: 0 0 8px var(--amber);
-                animation: pulse 2s ease-in-out infinite;
-            }
-
-            @keyframes pulse {
-                0%, 100% { opacity: 1; transform: scale(1); }
-                50% { opacity: 0.4; transform: scale(0.85); }
-            }
-
-            .section-head.muted {
-                color: var(--copy-faint);
-                margin-bottom: 0;
-                font-size: 9px;
-            }
-
-            .live-line {
-                font-family: var(--font-mono);
-                color: var(--amber);
-                font-size: 13px;
-                font-weight: 600;
-                display: flex;
-                align-items: center;
-                gap: 6px;
-                margin-top: 2px;
-            }
-
-            .watching-stack {
-                display: flex;
-                flex-direction: column;
-                gap: 14px;
-            }
-
-            .watch-file {
-                display: flex;
-                flex-direction: column;
-                gap: 6px;
-            }
-
-            .watch-file-head {
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                font-family: var(--font-mono);
-                color: var(--copy-dim);
-                font-size: 11px;
-                font-weight: 600;
-                padding: 4px 0;
-                border-bottom: 1px solid var(--border-subtle);
-            }
-
-            .watch-count {
-                color: var(--copy-faint);
-                font-size: 11px;
-            }
-
-            .watch-card {
-                background: var(--panel-2);
-                border-left: 2px solid var(--yellow);
-                padding: 12px 14px 10px;
-            }
-
-            .watch-critical { border-left-color: var(--red); }
-            .watch-high { border-left-color: var(--amber); }
-            .watch-medium { border-left-color: var(--yellow); }
-            .watch-low, .watch-info { border-left-color: var(--green); }
-
-            .watch-head {
-                display: grid;
-                grid-template-columns: 18px 1fr auto;
-                gap: 8px;
-                align-items: center;
-                margin-bottom: 6px;
-            }
-
-            .watch-icon {
-                display: flex;
-                align-items: center;
-            }
-
-            .watch-title {
-                font-size: 14px;
-                font-weight: 700;
-                color: var(--copy);
-            }
-
-            .watch-badge {
-                font-family: var(--font-mono);
-                font-size: 9px;
-                font-weight: 800;
-                letter-spacing: 0.06em;
-                padding: 2px 6px;
-                border: 1px solid rgba(255,255,255,0.1);
-            }
-
-            .sev-critical { color: var(--red); border-color: rgba(224,90,90,0.3); }
-            .sev-high { color: var(--amber); border-color: rgba(255,157,18,0.3); }
-            .sev-medium { color: var(--yellow); border-color: rgba(223,193,91,0.3); }
-            .sev-low { color: var(--green); border-color: rgba(122,153,112,0.3); }
-
-            .watch-copy {
-                color: var(--copy-dim);
-                font-size: 12px;
-                line-height: 1.5;
-                margin-bottom: 8px;
-            }
-
-            .watch-meta {
-                font-family: var(--font-mono);
-                color: var(--copy-faint);
-                font-size: 10px;
-            }
-
-            .watch-sep {
-                margin: 0 6px;
-                opacity: 0.5;
-            }
-
-            .user-strip {
-                display: flex;
-                justify-content: space-between;
-                align-items: center;
-                background: var(--panel);
-                border: 1px solid var(--border-subtle);
-                padding: 8px 12px;
-                margin-top: -6px;
-            }
-
-            .user-info {
-                display: flex;
-                align-items: center;
-                gap: 8px;
-            }
-
-            .user-avatar {
-                width: 24px;
-                height: 24px;
-                border-radius: 50%;
-                background: var(--amber);
-                color: #1A1000;
-                font-family: var(--font-mono);
-                font-size: 11px;
-                font-weight: 800;
-                display: grid;
-                place-items: center;
-                flex-shrink: 0;
-            }
-
-            .user-name {
-                font-family: var(--font-mono);
-                font-size: 11px;
-                font-weight: 600;
-                color: var(--copy);
-                letter-spacing: 0.02em;
-            }
-
-            .ide-badge {
-                display: flex;
-                align-items: center;
-                gap: 4px;
-                font-family: var(--font-mono);
-                font-size: 9px;
-                font-weight: 700;
-                color: var(--copy-dim);
-                letter-spacing: 0.06em;
-                background: var(--panel-2);
-                border: 1px solid var(--border);
-                padding: 3px 8px;
-                border-radius: 4px;
-            }
-
-            .user-actions {
-                display: flex;
-                align-items: center;
-                gap: 6px;
-            }
-
-            .logout-btn {
-                display: grid;
-                place-items: center;
-                padding: 4px;
-                background: transparent;
-                border: 1px solid var(--border);
-                border-radius: 4px;
-                color: var(--copy-dim);
-                cursor: pointer;
-                transition: all 0.15s ease;
-            }
-
-            .logout-btn:hover {
-                background: rgba(224, 90, 90, 0.12);
-                border-color: #E05A5A;
-                color: #E05A5A;
-            }
-
-            .dropdown-wrap {
-                position: relative;
-            }
-
-            .dropdown-menu {
-                display: none;
-                position: absolute;
-                top: calc(100% + 6px);
-                right: 0;
-                min-width: 160px;
-                background: var(--panel);
-                border: 1px solid var(--border);
-                border-radius: 6px;
-                padding: 4px 0;
-                z-index: 100;
-                box-shadow: 0 8px 24px rgba(0,0,0,0.4);
-                animation: dropIn 0.12s ease-out;
-            }
-
-            .dropdown-menu.open {
-                display: block;
-            }
-
-            @keyframes dropIn {
-                from { opacity: 0; transform: translateY(-4px); }
-                to   { opacity: 1; transform: translateY(0); }
-            }
-
-            .dropdown-item {
-                display: flex;
-                align-items: center;
-                gap: 8px;
-                width: 100%;
-                padding: 7px 12px;
-                background: none;
-                border: none;
-                color: var(--copy);
-                font-family: var(--font-mono);
-                font-size: 11px;
-                cursor: pointer;
-                text-align: left;
-                transition: background 0.1s;
-            }
-
-            .dropdown-item:hover {
-                background: var(--panel-2);
-            }
-
-            .dropdown-item.danger {
-                color: #E05A5A;
-            }
-
-            .dropdown-item.danger:hover {
-                background: rgba(224, 90, 90, 0.1);
-            }
-
-            .dropdown-sep {
-                height: 1px;
-                background: var(--border);
-                margin: 4px 0;
-            }
-
-            ::-webkit-scrollbar { width: 6px; }
-            ::-webkit-scrollbar-track { background: transparent; }
-            ::-webkit-scrollbar-thumb { background: var(--border); border-radius: 3px; }
-            ::-webkit-scrollbar-thumb:hover { background: var(--copy-faint); }
-        `;
-    }
+  }
+
+  private styles(): string {
+    return buildWebviewStyles("sidebar");
+  }
 }
 
 export const aegisSidebarPanel = new AegisSidebarPanel();

--- a/apps/extension/src/ui/webviewTheme.ts
+++ b/apps/extension/src/ui/webviewTheme.ts
@@ -1,0 +1,1257 @@
+export const WEBVIEW_FONT_CSP =
+  "font-src https://fonts.gstatic.com https://fonts.googleapis.com; style-src 'unsafe-inline' https://fonts.googleapis.com;";
+
+const FONT_IMPORT = `@import url('https://fonts.googleapis.com/css2?family=Geist:wght@100;200;300;400;500;600&family=IBM+Plex+Mono:wght@300;400;500;600&family=Instrument+Serif:ital@0;1&display=swap');`;
+
+const TOKENS = `
+:root {
+    --bg: #0E0D0C;
+    --bg-card: #141210;
+    --surface: #1A1714;
+    --panel: #141210;
+    --panel-2: #1A1714;
+    --border: #2E2A26;
+    --border-subtle: rgba(46, 42, 38, 0.6);
+    --white: #F5F2EE;
+    --copy: #F5F2EE;
+    --grey: #A89F94;
+    --copy-dim: #A89F94;
+    --grey-dim: #4A4440;
+    --copy-faint: #4A4440;
+    --amber: #C4701F;
+    --amber-hover: #D4762A;
+    --vuln: #D4762A;
+    --sage: #7A9970;
+    --red: #D4762A;
+    --yellow: #C4701F;
+    --font-sans: "Geist", system-ui, -apple-system, sans-serif;
+    --font-serif: "Instrument Serif", Georgia, serif;
+    --font-mono: "IBM Plex Mono", "Menlo", "Consolas", monospace;
+}
+`;
+
+const BASE = `
+${FONT_IMPORT}
+${TOKENS}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+    background: var(--bg);
+    color: var(--copy);
+    font-family: var(--font-sans);
+    font-size: 12px;
+    font-weight: 400;
+    line-height: 1.5;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    position: relative;
+}
+
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background-image: radial-gradient(circle, #2A2724 1px, transparent 1px);
+    background-size: 28px 28px;
+    opacity: 0.45;
+    pointer-events: none;
+    z-index: 0;
+}
+
+body::after {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background: radial-gradient(circle 280px at 50% 0%, rgba(196, 112, 31, 0.05) 0%, transparent 100%);
+    pointer-events: none;
+    z-index: 0;
+}
+
+button {
+    font-family: inherit;
+    color: inherit;
+    cursor: pointer;
+    border: none;
+    background: none;
+    outline: none;
+}
+
+.shell {
+    position: relative;
+    z-index: 1;
+    min-height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+.font-serif {
+    font-family: var(--font-serif);
+}
+
+.font-mono {
+    font-family: var(--font-mono);
+}
+
+.section-head {
+    font-family: var(--font-mono);
+    color: var(--grey-dim);
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+}
+
+.section-title {
+    font-family: var(--font-mono);
+    color: var(--copy);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding-top: 4px;
+}
+
+.primary-btn {
+    width: 100%;
+    background: var(--amber);
+    color: var(--bg);
+    padding: 12px;
+    font-size: 10px;
+    font-weight: 600;
+    font-family: var(--font-mono);
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    transition: background 0.15s ease, transform 0.15s ease;
+    border: none;
+    border-radius: 2px;
+}
+
+.primary-btn:hover {
+    background: var(--amber-hover);
+}
+
+.primary-btn:active {
+    transform: translateY(1px);
+}
+
+.secondary-btn {
+    width: 100%;
+    background: transparent;
+    color: var(--copy);
+    border: 1px solid var(--border);
+    padding: 10px;
+    font-size: 10px;
+    font-weight: 600;
+    font-family: var(--font-mono);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    transition: all 0.15s ease;
+    border-radius: 2px;
+}
+
+.secondary-btn:hover {
+    background: var(--surface);
+    border-color: var(--amber);
+    color: var(--white);
+}
+
+.secondary-btn.compact {
+    padding: 9px 8px;
+    font-size: 9px;
+}
+
+.text-btn {
+    width: 100%;
+    padding: 8px 12px;
+    color: var(--grey-dim);
+    font-size: 11px;
+    font-family: var(--font-mono);
+    letter-spacing: 0.06em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    transition: color 0.15s ease;
+}
+
+.text-btn:hover {
+    color: var(--copy);
+}
+
+.card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    padding: 14px;
+}
+
+.empty-copy {
+    color: var(--grey-dim);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.04em;
+    text-align: center;
+    padding: 16px 0;
+}
+
+.icon-btn {
+    width: 28px;
+    height: 28px;
+    display: grid;
+    place-items: center;
+    border-radius: 2px;
+    color: var(--grey-dim);
+    transition: all 0.15s ease;
+}
+
+.icon-btn:hover {
+    background: var(--surface);
+    color: var(--copy);
+}
+
+::-webkit-scrollbar { width: 5px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 2px; }
+::-webkit-scrollbar-thumb:hover { background: var(--grey-dim); }
+`;
+
+const SIDEBAR = `
+.topbar {
+    height: 52px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 12px;
+    border-bottom: 1px solid var(--border);
+    background: rgba(14, 13, 12, 0.92);
+}
+
+.brand-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    min-width: 0;
+}
+
+.brand-wordmark {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-size: 16px;
+    color: var(--white);
+    line-height: 1;
+    white-space: nowrap;
+}
+
+.brand-sub {
+    font-family: var(--font-mono);
+    font-size: 8px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--grey-dim);
+    margin-top: 2px;
+}
+
+.status-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 2px 8px;
+    border-radius: 2px;
+    font-family: var(--font-mono);
+    font-size: 8px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    border: 1px solid var(--border);
+    white-space: nowrap;
+}
+
+.status-badge.active {
+    background: rgba(122, 153, 112, 0.08);
+    color: var(--sage);
+    border-color: rgba(122, 153, 112, 0.25);
+}
+
+.status-badge.watching {
+    background: rgba(196, 112, 31, 0.08);
+    color: var(--amber-hover);
+    border-color: rgba(196, 112, 31, 0.25);
+}
+
+.top-actions {
+    display: flex;
+    gap: 2px;
+    flex-shrink: 0;
+}
+
+.content {
+    flex: 1;
+    padding: 14px 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+}
+
+.center-panel {
+    margin: auto 0;
+    padding: 24px 12px 20px;
+    text-align: center;
+}
+
+.center-icon {
+    width: 56px;
+    height: 56px;
+    margin: 0 auto 18px;
+    border-radius: 2px;
+    display: grid;
+    place-items: center;
+    border: 1px solid var(--border);
+}
+
+.center-icon.shield {
+    background: var(--bg-card);
+    color: var(--amber);
+}
+
+.center-icon.offline {
+    background: rgba(212, 118, 42, 0.06);
+    color: var(--vuln);
+    border-color: rgba(212, 118, 42, 0.2);
+}
+
+.wordmark-block {
+    margin-bottom: 20px;
+}
+
+.wordmark {
+    display: block;
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-size: 22px;
+    color: var(--white);
+    margin-bottom: 4px;
+}
+
+.descriptor {
+    font-family: var(--font-sans);
+    font-weight: 200;
+    font-size: 9px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--grey-dim);
+}
+
+.hero-title {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-size: 22px;
+    font-weight: 400;
+    color: var(--white);
+    margin-bottom: 10px;
+    line-height: 1.15;
+}
+
+.hero-copy {
+    color: var(--grey);
+    font-size: 13px;
+    font-weight: 300;
+    line-height: 1.65;
+    margin-bottom: 20px;
+}
+
+.error-box {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-left: 2px solid var(--vuln);
+    border-radius: 2px;
+    padding: 12px;
+    text-align: left;
+    margin-bottom: 18px;
+}
+
+.error-code {
+    color: var(--vuln);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    margin-bottom: 6px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.error-detail {
+    color: var(--grey);
+    font-size: 11px;
+    line-height: 1.55;
+}
+
+.btn-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.footer-status {
+    text-align: center;
+    color: var(--grey-dim);
+    font-family: var(--font-mono);
+    font-size: 9px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    padding: 8px 0;
+}
+
+.primary-btn.watch-btn {
+    background: transparent;
+    border: 1px solid var(--border);
+    color: var(--copy);
+}
+
+.primary-btn.watch-btn:hover {
+    border-color: var(--amber);
+    color: var(--white);
+    background: var(--surface);
+}
+
+.meta-strip {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    color: var(--grey-dim);
+    font-family: var(--font-mono);
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.meta-strip.sub {
+    margin-top: -8px;
+    font-size: 8px;
+    opacity: 0.85;
+}
+
+.status-badge-inline {
+    font-family: var(--font-mono);
+    font-size: 8px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    padding: 2px 7px;
+    border-radius: 2px;
+    border: 1px solid var(--border);
+    color: var(--grey-dim);
+}
+
+.status-badge-inline.active {
+    background: rgba(122, 153, 112, 0.08);
+    color: var(--sage);
+    border-color: rgba(122, 153, 112, 0.25);
+}
+
+.summary-card {
+    display: flex;
+    justify-content: space-between;
+    align-items: stretch;
+    gap: 10px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    padding: 14px;
+}
+
+.summary-left {
+    display: flex;
+    flex-direction: column;
+}
+
+.score-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 2px;
+}
+
+.score-value {
+    font-family: var(--font-mono);
+    font-size: 38px;
+    line-height: 1;
+    font-weight: 600;
+    color: var(--white);
+    letter-spacing: -0.04em;
+}
+
+.score-max {
+    font-family: var(--font-mono);
+    color: var(--grey-dim);
+    font-size: 12px;
+    font-weight: 500;
+    margin-bottom: 5px;
+}
+
+.risk-pill {
+    min-width: 88px;
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    align-items: flex-end;
+}
+
+.risk-label-text {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+}
+
+.risk-critical, .risk-high { color: var(--vuln); }
+.risk-medium { color: var(--amber); }
+.risk-low { color: var(--sage); }
+
+.threat-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+}
+
+.threat-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    padding: 10px;
+    min-height: 76px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+}
+
+.threat-label {
+    font-family: var(--font-mono);
+    color: var(--grey-dim);
+    font-size: 8px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    margin-bottom: 10px;
+}
+
+.threat-row {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+}
+
+.threat-value {
+    font-family: var(--font-mono);
+    font-size: 22px;
+    line-height: 1;
+    font-weight: 600;
+}
+
+.recent-list {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+
+.recent-row {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 22px 1fr auto;
+    gap: 10px;
+    align-items: center;
+    padding: 9px 4px;
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid var(--border-subtle);
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.12s ease;
+}
+
+.recent-row:hover {
+    background: rgba(26, 23, 20, 0.65);
+}
+
+.file-icon {
+    display: flex;
+    align-items: center;
+    color: var(--grey-dim);
+}
+
+.file-icon.js { color: #F0DB4F; }
+.file-icon.py { color: #3572A5; }
+.file-icon.css { color: #563D7C; }
+.file-icon.json { color: var(--amber); }
+.file-icon.folder { color: var(--amber); }
+
+.recent-file {
+    font-family: var(--font-sans);
+    color: var(--copy);
+    font-size: 12px;
+    font-weight: 400;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.issue-section {
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    padding: 12px;
+    background: var(--bg-card);
+}
+
+.issue-row {
+    display: flex;
+    align-items: center;
+    padding: 7px 0;
+    border-bottom: 1px solid var(--border-subtle);
+}
+
+.issue-row:last-child { border-bottom: none; }
+
+.issue-row.total {
+    border-top: 1px solid var(--border);
+    margin-top: 4px;
+    padding-top: 9px;
+}
+
+.issue-dot {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    margin-right: 10px;
+    flex-shrink: 0;
+}
+
+.issue-label {
+    flex: 1;
+    font-size: 12px;
+    color: var(--grey);
+}
+
+.issue-value {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 600;
+}
+
+.footer-panel {
+    margin-top: auto;
+    padding-top: 10px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.split-actions {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+}
+
+.footer-meta {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    font-family: var(--font-mono);
+    color: var(--grey-dim);
+    font-size: 9px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding-top: 2px;
+}
+
+.online { color: var(--sage); }
+.idle { color: var(--grey-dim); }
+
+.watching-head { padding-top: 2px; }
+
+.live-indicator {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 4px;
+}
+
+.live-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--amber);
+    box-shadow: 0 0 8px rgba(196, 112, 31, 0.45);
+    animation: pulse 2s ease-in-out infinite;
+}
+
+@keyframes pulse {
+    0%, 100% { opacity: 1; transform: scale(1); }
+    50% { opacity: 0.45; transform: scale(0.88); }
+}
+
+.section-head.muted {
+    color: var(--grey-dim);
+    margin-bottom: 0;
+    font-size: 8px;
+}
+
+.live-line {
+    font-family: var(--font-mono);
+    color: var(--amber-hover);
+    font-size: 11px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 2px;
+}
+
+.watching-stack {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.watch-file {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.watch-file-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-family: var(--font-mono);
+    color: var(--grey-dim);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    padding: 4px 0;
+    border-bottom: 1px solid var(--border);
+}
+
+.watch-count {
+    color: var(--grey);
+    font-size: 9px;
+}
+
+.watch-card {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-left: 2px solid var(--amber);
+    border-radius: 2px;
+    padding: 10px 12px;
+}
+
+.watch-critical { border-left-color: var(--vuln); }
+.watch-high { border-left-color: var(--vuln); }
+.watch-medium { border-left-color: var(--amber); }
+.watch-low, .watch-info { border-left-color: var(--sage); }
+
+.watch-head {
+    display: grid;
+    grid-template-columns: 18px 1fr auto;
+    gap: 8px;
+    align-items: center;
+    margin-bottom: 6px;
+}
+
+.watch-title {
+    font-family: var(--font-sans);
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--white);
+}
+
+.watch-badge {
+    font-family: var(--font-mono);
+    font-size: 8px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    padding: 2px 6px;
+    border: 1px solid var(--border);
+    border-radius: 2px;
+}
+
+.sev-critical, .sev-high { color: var(--vuln); border-color: rgba(212, 118, 42, 0.25); }
+.sev-medium { color: var(--amber); border-color: rgba(196, 112, 31, 0.25); }
+.sev-low { color: var(--sage); border-color: rgba(122, 153, 112, 0.25); }
+
+.watch-copy {
+    color: var(--grey);
+    font-size: 11px;
+    line-height: 1.55;
+    margin-bottom: 8px;
+}
+
+.watch-meta {
+    font-family: var(--font-mono);
+    color: var(--grey-dim);
+    font-size: 9px;
+    letter-spacing: 0.04em;
+}
+
+.watch-sep {
+    margin: 0 6px;
+    opacity: 0.5;
+}
+
+.user-strip {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    padding: 8px 10px;
+    margin-top: -4px;
+}
+
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+}
+
+.user-avatar {
+    width: 24px;
+    height: 24px;
+    border-radius: 2px;
+    background: rgba(196, 112, 31, 0.12);
+    border: 1px solid rgba(196, 112, 31, 0.25);
+    color: var(--amber-hover);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    display: grid;
+    place-items: center;
+    flex-shrink: 0;
+}
+
+.user-name {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 500;
+    color: var(--copy);
+    letter-spacing: 0.04em;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.ide-badge {
+    font-family: var(--font-mono);
+    font-size: 8px;
+    font-weight: 500;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--grey-dim);
+    background: var(--bg);
+    border: 1px solid var(--border);
+    padding: 3px 7px;
+    border-radius: 2px;
+    white-space: nowrap;
+}
+
+.user-actions {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.logout-btn {
+    display: grid;
+    place-items: center;
+    padding: 4px;
+    background: transparent;
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    color: var(--grey-dim);
+    cursor: pointer;
+    transition: all 0.15s ease;
+}
+
+.logout-btn:hover {
+    background: rgba(212, 118, 42, 0.08);
+    border-color: var(--vuln);
+    color: var(--vuln);
+}
+
+.dropdown-wrap { position: relative; }
+
+.dropdown-menu {
+    display: none;
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    min-width: 168px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    padding: 4px 0;
+    z-index: 100;
+    box-shadow: 0 10px 28px rgba(0, 0, 0, 0.35);
+}
+
+.dropdown-menu.open { display: block; }
+
+.dropdown-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 7px 12px;
+    background: none;
+    border: none;
+    color: var(--copy);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.1s;
+}
+
+.dropdown-item:hover { background: var(--surface); }
+.dropdown-item.danger { color: var(--vuln); }
+.dropdown-item.danger:hover { background: rgba(212, 118, 42, 0.08); }
+.dropdown-sep {
+    height: 1px;
+    background: var(--border);
+    margin: 4px 0;
+}
+`;
+
+const FINDINGS = `
+.findings-shell {
+    min-height: 100vh;
+    padding: 14px 12px 20px;
+}
+
+.header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 16px;
+}
+
+.header-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.header-title {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-size: 18px;
+    color: var(--white);
+    line-height: 1;
+}
+
+.count-badge {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    padding: 2px 7px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    color: var(--grey-dim);
+}
+
+.header-actions {
+    display: flex;
+    gap: 4px;
+}
+
+.focus-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--vuln);
+    border-radius: 2px;
+    padding: 16px 14px;
+    margin-bottom: 12px;
+}
+
+.severity-critical, .severity-high { border-left-color: var(--vuln); }
+.severity-medium { border-left-color: var(--amber); }
+.severity-low, .severity-info { border-left-color: var(--sage); }
+
+.focus-head {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 8px;
+}
+
+.focus-label {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.focus-confidence {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    color: var(--grey-dim);
+    padding: 3px 8px;
+    font-family: var(--font-mono);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    border-radius: 2px;
+}
+
+.focus-title {
+    font-family: var(--font-serif);
+    font-size: 22px;
+    font-weight: 400;
+    line-height: 1.15;
+    color: var(--white);
+    margin-bottom: 10px;
+}
+
+.focus-meta {
+    color: var(--grey-dim);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    margin-bottom: 16px;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.dot {
+    color: var(--grey-dim);
+    margin: 0 4px;
+}
+
+.focus-description {
+    color: var(--grey);
+    font-size: 12px;
+    font-weight: 300;
+    line-height: 1.65;
+    margin-bottom: 16px;
+}
+
+.code-card {
+    background: var(--bg);
+    border: 1px solid var(--border);
+    border-radius: 2px;
+    margin-bottom: 14px;
+    overflow: hidden;
+}
+
+.code-meta {
+    display: flex;
+    justify-content: space-between;
+    padding: 8px 12px;
+    border-bottom: 1px solid var(--border);
+    font-family: var(--font-mono);
+    color: var(--grey-dim);
+    font-size: 9px;
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.code-block {
+    margin: 0;
+    padding: 12px;
+    white-space: pre-wrap;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    line-height: 1.65;
+    color: var(--grey);
+}
+
+.primary-action {
+    width: 100%;
+    background: var(--amber);
+    color: var(--bg);
+    padding: 12px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-bottom: 8px;
+    border-radius: 2px;
+    transition: background 0.15s ease;
+}
+
+.primary-action:hover { background: var(--amber-hover); }
+
+.action-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 6px;
+    margin-bottom: 14px;
+}
+
+.action-btn {
+    width: 100%;
+    background: var(--bg-card);
+    color: var(--copy);
+    border: 1px solid var(--border);
+    padding: 10px 8px;
+    font-size: 9px;
+    font-weight: 600;
+    font-family: var(--font-mono);
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    border-radius: 2px;
+    transition: all 0.15s ease;
+}
+
+.action-btn:hover {
+    background: var(--surface);
+    border-color: var(--amber);
+}
+
+.finding-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.finding-item {
+    width: 100%;
+    background: transparent;
+    padding: 10px 8px;
+    text-align: left;
+    border-bottom: 1px solid var(--border-subtle);
+    transition: background 0.12s ease;
+}
+
+.finding-item:hover { background: rgba(26, 23, 20, 0.65); }
+
+.finding-row {
+    display: grid;
+    grid-template-columns: 16px 1fr auto;
+    gap: 10px;
+    align-items: center;
+}
+
+.finding-severity {
+    font-family: var(--font-mono);
+    font-size: 8px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+}
+
+.finding-title {
+    color: var(--white);
+    font-size: 12px;
+    font-weight: 500;
+}
+
+.finding-location {
+    font-family: var(--font-mono);
+    color: var(--grey-dim);
+    font-size: 9px;
+    text-align: right;
+}
+
+.empty-state {
+    min-height: 70vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+}
+
+.empty-icon {
+    width: 56px;
+    height: 56px;
+    border-radius: 2px;
+    background: var(--bg-card);
+    border: 1px solid var(--border);
+    display: grid;
+    place-items: center;
+    color: var(--amber);
+    margin-bottom: 16px;
+}
+
+.empty-title {
+    font-family: var(--font-serif);
+    font-style: italic;
+    font-size: 22px;
+    color: var(--white);
+    margin-bottom: 8px;
+}
+
+.empty-copy-text {
+    color: var(--grey);
+    font-size: 12px;
+    font-weight: 300;
+    max-width: 280px;
+    line-height: 1.6;
+}
+`;
+
+export function buildWebviewStyles(panel: 'sidebar' | 'findings'): string {
+    if (panel === 'findings') {
+        return `${BASE}${FINDINGS}`;
+    }
+    return `${BASE}${SIDEBAR}`;
+}
+
+export function severityColor(severity: string): string {
+    switch (severity.toLowerCase()) {
+        case 'critical':
+        case 'high':
+            return '#D4762A';
+        case 'medium':
+            return '#C4701F';
+        case 'low':
+        case 'clean':
+            return '#7A9970';
+        default:
+            return '#4A4440';
+    }
+}

--- a/apps/web/app/components/hero/Headline.tsx
+++ b/apps/web/app/components/hero/Headline.tsx
@@ -1,9 +1,9 @@
 export default function Headline() {
-    return (
-        <div className="headline">
-            <span className="headline-line">Your AI Writes Code.</span>
-            <span className="headline-line">AegisCode Watches</span>
-            <span className="headline-line">Every Line of It.</span>
-        </div>
-    );
+  return (
+    <div className="headline">
+      <span className="headline-line">Your AI Writes Code.</span>
+      <span className="headline-line">AegisCode Watches</span>
+      <span className="headline-line">Every Line of It.</span>
+    </div>
+  );
 }

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -15,6 +15,19 @@
 
     --font-sans: "Geist", system-ui, sans-serif;
     --font-mono: "IBM Plex Mono", monospace;
+
+    /* Hero section & global UI variables */
+    --amber-grad-a: #D47C2F;
+    --amber-grad-b: #E8C97A;
+    --border-tag: #7A6020;
+    --amber-tag: #BFA560;
+    --grey-sub: #7A746E;
+    --white-cta: #F5F2EE;
+    --bg-terminal: #141210;
+    --border-term: #2E2A26;
+    --grey-term: #4A4440;
+    --term-file: #F5F2EE;
+    --amber-vuln: #D4762A;
 }
 
 body {


### PR DESCRIPTION
- implemented proper fonts instrument serif , ibm plex mono and geist to match the web page aesthetics

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies the extension’s webview styling with the website and switches typography to Geist, IBM Plex Mono, and Instrument Serif. This removes ad‑hoc styles, standardizes severity colors, and enables safe remote font loading.

- New Features
  - Added `webviewTheme.ts` with `buildWebviewStyles`, theme tokens, severity color helpers, and `WEBVIEW_FONT_CSP` for Google Fonts.
  - Applied the theme and fonts to Active Findings and Aegis Sidebar panels.

- Refactors
  - Replaced inline severity color maps with theme-provided colors.
  - Centralized CSS and icon styling to reduce duplication.
  - Switched IDE label to `getIdeClientName()` in extension state.
  - Minor cleanup in `Headline.tsx` and added shared color variables in `globals.css` to align palettes.

<sup>Written for commit eeb608756a36ee848dba0fd32e3f27f5f034d9ab. Summary will update on new commits. <a href="https://cubic.dev/pr/AnjanyKumarJaiswal/AegisCode/pull/18?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved IDE detection in extension
  * Redesigned active findings panel with updated labels ("Why this is a risk" and "Recommended fix")
  * Enhanced sidebar with theme-based colors and refined styling

* **Improvements**
  * Consistent severity color handling across webview panels
  * Added global color theme variables for UI elements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/AnjanyKumarJaiswal/AegisCode/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->